### PR TITLE
Added free() to destructor to avoid memory leak

### DIFF
--- a/Average.h
+++ b/Average.h
@@ -56,6 +56,7 @@ template <class T> class Average {
         // Public functions and variables.  These can be accessed from
         // outside the class.
         Average(uint32_t size);
+        ~Average();
         float rolling(T entry);
         void push(T entry);
         float mean();
@@ -81,6 +82,10 @@ template <class T> Average<T>::Average(uint32_t size) {
     for (uint32_t i = 0; i < size; i++) {
         _store[i] = 0;
     }
+}
+
+template <class T> Average<T>::~Average() {
+    free(_store);
 }
 
 template <class T> void Average<T>::push(T entry) {


### PR DESCRIPTION
Every invocation of Average will currently leak memory when it goes out of scope. I don't know if this is by design to suggest to the user that they should probably use Average in a global scope/startup as I've heard theres some issues using malloc/free on AVR/Arduino?

I've not done any thorough testing of this but it seems to work for me without issue and stops exhaustion of the RAM  
